### PR TITLE
Fix typos

### DIFF
--- a/cards.js
+++ b/cards.js
@@ -21049,7 +21049,7 @@ export const cards = [
         ],
         "cost": 1,
         "rarity": "Uncommon",
-        "flavorText": "\u2018\u201c\u201cHang on, I\u2019ll get my Firebolt.\u201d\u2019 \u2014 Harry Potter",
+        "flavorText": "\u201cHang on, I\u2019ll get my Firebolt.\u201d \u2014 Harry Potter",
         "effect": [
             "Whenever you win a Match by completing it's \"To Win,\" you get 1 more Action this turn."
         ],

--- a/cards.js
+++ b/cards.js
@@ -20388,7 +20388,7 @@ export const cards = [
         "rarity": "Rare",
         "flavorText": "Play now reached a level of ferocity beyond anything they had yet seen. The Beaters on both sides were acting without mercy....\"",
         "effect": [
-            "Count the number of Q Items you have in play. Do 3 times that much damage to an opponent."
+            "Count the number of [Q] Items you have in play. Do 3 times that much damage to an opponent."
         ],
         "setName": "Goblet of Fire",
         "imgSrc": "Bumphing.png",
@@ -21378,7 +21378,7 @@ export const cards = [
         "cost": 4,
         "rarity": "Uncommon",
         "effect": [
-            "Once during each player's turn, when they use an Action to play a Quidditch card, they may search their deck for a Q Lesson and put it into play, then shuffle their deck."
+            "Once during each player's turn, when they use an Action to play a Quidditch card, they may search their deck for a [Q] Lesson and put it into play, then shuffle their deck."
         ],
         "note": "When you play this card, discard any other Location from play (yours or an opponent's).",
         "setName": "Goblet of Fire",
@@ -21512,7 +21512,7 @@ export const cards = [
         "cost": 5,
         "rarity": "Uncommon",
         "effect": [
-            "Whenever one of your Q Spells does damage, you may discard this card from play. If you do, it does 5 more damage."
+            "Whenever one of your [Q] Spells does damage, you may discard this card from play. If you do, it does 5 more damage."
         ],
         "provides": [
             {


### PR DESCRIPTION
### Lesson type notation

As far as I can tell, the modern way of writing the effect of a card is to use the symbols `[C]`, `[F]`, `[P]`, `[Q]`, and `[T]`. I noticed a few mentions of `Q` instead of `[Q]`, so I changed those.

### Typo fix

I fixed a typo with the quotation marks in the flavor text of one card.