### PR TITLE
Add new set to search abreviations, and default to blank string

### DIFF
--- a/Search_Display.js
+++ b/Search_Display.js
@@ -50,7 +50,8 @@ const setAbbreviations = {
     "SOH": "Streets of HogsMeade",
     "EOTP": "Echoes of the Past",
     "PRO": "Promotional",
-    "QWF": "Quidditch World Finals"
+    "QWF": "Quidditch World Finals",
+    "LM1": "Lost Magic 1"
 };
 
 const classicSetKeys = ["QC", "DA", "AAH", "COS", "B"]
@@ -292,7 +293,7 @@ function filterCard(card, terms) {
                 case 'set':
                 case 'setname':
                     let setName = card.setName?.toLowerCase();
-                    let setAbbreviation = Object.keys(setAbbreviations).find(abbr => setAbbreviations[abbr].toLowerCase() === setName);
+                    let setAbbreviation = Object.keys(setAbbreviations).find(abbr => setAbbreviations[abbr].toLowerCase() === setName) || "";
 
                     const queryLower = query.toLowerCase();
 


### PR DESCRIPTION
There's a small bug with the set search, if the set isn't part of the `setAbbreviations` lookup, then the `setAbbreviation` variable is undefined for those cards, causing the lookup to fail.

This change fixes two-fold; add the new set in to the lookup, and also default the `setAbbreviation` variable to an empty string if no set found